### PR TITLE
Adding an option to set the counter of a website to 0

### DIFF
--- a/popup/exploding-tabs.js
+++ b/popup/exploding-tabs.js
@@ -20,7 +20,7 @@ function decrementTimer(){
     browser.storage.local.get(siteKey).then( function( results ){
         timer = results[siteKey].timer;
         timer -= 60;
-        if( timer > 0 ){
+        if( timer >= 0 ){
             browser.storage.local.set({
                 [siteKey]: {timer: timer}
             }).then(updateExplodingSites,onError);


### PR DESCRIPTION
Hi Kerem,

This is a pull request to allow for setting time timer to 0, instead of a minimum of 60 seconds.
If this conflicts with Exploding tabs use case, or the change to (>= 0) causes other problems, then can reject the pull request.

Thanks,
Sameer